### PR TITLE
Update mytftp.c

### DIFF
--- a/mytftp.c
+++ b/mytftp.c
@@ -296,6 +296,7 @@ void recv_data(int sockfd, char *filename) {
 		/* Receive the DATA */
 		if (is_debugging) printf("Waiting for DATA...\n");
 		alarm(TIMEOUT_SECS); // start new timer
+		memset(dataPacket, 0, sizeof(TFTP_Data));
 		n = recvfrom(sockfd, dataPacket, sizeof(TFTP_Data), 0, (struct sockaddr *)&client_addr, &clilen);
 		timeout = 0;
 		alarm(0); // void timer


### PR DESCRIPTION
作为服务端每次接收数据时要把dataPacket清空，否则最后一次接收数据小于512字节时，会把上一次的部分数据也保存到文件里。